### PR TITLE
Enhancements and bug fixes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -15,7 +15,7 @@ namespace ESP32_ExceptionDecoder
         static string addr2Line = "";
         static string traceDecode(string trace)
         {
-            var p = new Process() { StartInfo = new ProcessStartInfo(addr2Line, "-e " + string.Format(elf, build) + " -f -p ESP32  " + trace ) { UseShellExecute = false, RedirectStandardOutput = true, /* RedirectStandardInput = false*/ } };
+            var p = new Process() { StartInfo = new ProcessStartInfo(addr2Line, "-e " + string.Format(elf, build) + " -p ESP32  " + trace) { UseShellExecute = false, RedirectStandardOutput = true } };
             p.Start();
             return p.StandardOutput.ReadToEnd();
         }
@@ -298,14 +298,15 @@ namespace ESP32_ExceptionDecoder
             if (usePort)
                 while (true)
                 {
-                    var inStream = Console.OpenStandardInput();
-                    StreamReader sr = new(inStream);
-                    var rLine = sr.ReadLine();
-                    sp.WriteLine(rLine);
-                    rLine = sr.ReadLine();
+                    // send individual keyboard characters to the serial port, not echoed to local screen
+                    if (Console.KeyAvailable)
+                    {
+                        var key = Console.ReadKey(true);
+                        sp.Write(key.KeyChar.ToString());
+                    }
                 }
             else
-                Console.WriteLine("Docoding ended.");
+                Console.WriteLine("Decoding ended.");
         }
 
     }

--- a/Program.cs
+++ b/Program.cs
@@ -113,7 +113,8 @@ namespace ESP32_ExceptionDecoder
             bool usePort = true;
             var comPort = SerialPort.GetPortNames().Last();
             int baud = 250000;
-            var allTrace = "";
+            string traceFilename = "";
+            string allTrace = "";
             for (int i = 0; i < args.Length; i += 2)
             {
                 if (args[i].StartsWith("-b") || args[i].StartsWith("--build"))
@@ -160,7 +161,7 @@ namespace ESP32_ExceptionDecoder
                 else if (args[i].StartsWith("-f") || args[i].StartsWith("--file"))
                 {
                     usePort = false;
-                    allTrace = args[i + 1];
+                    traceFilename = args[i + 1];
                 }
             }
 
@@ -186,15 +187,12 @@ namespace ESP32_ExceptionDecoder
             if (usePort)
                 Console.WriteLine("COM Port: {0} @{1}", comPort, baud);
             else
-                WriteErrorLine("Decoding Error: {0}", allTrace);
-
-            if (args.Length % 2 == 1)
             {
-                usePort = false;
-                if (File.Exists(args.Last()))
-                    allTrace = File.ReadAllText(allTrace);
+                Console.WriteLine("trace file: {0}", traceFilename);
+                if (File.Exists(traceFilename))
+                    allTrace = File.ReadAllText(traceFilename);
                 else
-                    allTrace = args.Last();
+                    WriteErrorLine("Cannot open file '{0}'", traceFilename);
             }
             Console.WriteLine("ESP32 Exception Decoder");
             var sp = new SerialPort(comPort, baud);
@@ -289,10 +287,11 @@ namespace ESP32_ExceptionDecoder
             }
             else
             {
-                Console.WriteLine("Using backtrace inf: {0}", allTrace);
-                foreach (var l in allTrace.Split('\r', 'n'))
+                Console.WriteLine("Using backtrace inf:\n{0}", allTrace);
+                foreach (var l in allTrace.Split('\r', '\n'))
                 {
-                    newLine(l);
+                    if (l.Length > 0)
+                        newLine(l);
                 }
             }
             if (usePort)

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,9 +1,7 @@
 {
   "profiles": {
     "ESP32_ExceptionDecoder": {
-      "commandName": "Project",
-      "commandLineArgs": "-a \"C:\\Users\\davet\\.platformio\\packages\\toolchain-xtensa-esp32s3\\bin\\xtensa-esp32s3-elf-addr2line.exe\" -f \"crash2.txt\"",
-      "workingDirectory": "D:\\Embedded\\PIO\\Traverser\\Controller"
+      "commandName": "Project"
     }
   }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "ESP32_ExceptionDecoder": {
+      "commandName": "Project",
+      "commandLineArgs": "-a \"C:\\Users\\davet\\.platformio\\packages\\toolchain-xtensa-esp32s3\\bin\\xtensa-esp32s3-elf-addr2line.exe\" -c \"COM5\" -s 115200",
+      "workingDirectory": "D:\\Embedded\\PIO\\Traverser\\Controller"
+    }
+  }
+}

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ESP32_ExceptionDecoder": {
       "commandName": "Project",
-      "commandLineArgs": "-a \"C:\\Users\\davet\\.platformio\\packages\\toolchain-xtensa-esp32s3\\bin\\xtensa-esp32s3-elf-addr2line.exe\" -c \"COM5\" -s 115200",
+      "commandLineArgs": "-a \"C:\\Users\\davet\\.platformio\\packages\\toolchain-xtensa-esp32s3\\bin\\xtensa-esp32s3-elf-addr2line.exe\" -f \"crash2.txt\"",
       "workingDirectory": "D:\\Embedded\\PIO\\Traverser\\Controller"
     }
   }

--- a/Readme.md
+++ b/Readme.md
@@ -79,7 +79,7 @@ You can also pass custom arguments to the tool if needed:
 - **`--build` or `-b`**: Specify the build directory or target build.
 - **`--elf` or `-e`**: Specify the **ELF file**.
 - **`--tools` or `-t`**: Specify the path to the **ESP32 toolchain** (default is detected automatically).
-- **`--addr2line` or `-a`**: Specify the full path & name of your addr2line utility** 
+- **`--addr2line` or `-a`**: Specify the full path & name of your **addr2line utility** 
 - **`--com` or `-c`**: Specify the **COM port** for serial communication.
 - **`--speed` or `-s`**: Specify the **baud rate** for serial communication (default is `250000`).
 - **`--file` or `-f`**: Use a **file** as input for backtrace logs instead of serial.

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,7 @@ This tool is a **custom exception decoder** for **ESP32** devices, designed to d
 - **File support**: Reads exception backtraces from an input file.
 - **Boot loop prevention**: Detects if the system is in a **boot loop** and halts further decoding.
 - **Exception decoding**: Uses the **`addr2line`** utility from the **ESP32 toolchain** to decode exception data and map memory addresses to the corresponding source code.
+- **Serial data to ESP32**: Transparently passes character-by-character keyboard input to the ESP32 via the serial port.  
 
 ## Installation
 
@@ -79,7 +80,7 @@ You can also pass custom arguments to the tool if needed:
 - **`--build` or `-b`**: Specify the build directory or target build.
 - **`--elf` or `-e`**: Specify the **ELF file**.
 - **`--tools` or `-t`**: Specify the path to the **ESP32 toolchain** (default is detected automatically).
-- **`--addr2line` or `-a`**: Specify the full path & name of your **addr2line utility** 
+- **`--addr2line` or `-a`**: Specify the full path & name of your **addr2line utility** (used when the utility is not named 'xtensa-esp32-elf-addr2line')
 - **`--com` or `-c`**: Specify the **COM port** for serial communication.
 - **`--speed` or `-s`**: Specify the **baud rate** for serial communication (default is `250000`).
 - **`--file` or `-f`**: Use a **file** as input for backtrace logs instead of serial.

--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ You can also pass custom arguments to the tool if needed:
 - **`--build` or `-b`**: Specify the build directory or target build.
 - **`--elf` or `-e`**: Specify the **ELF file**.
 - **`--tools` or `-t`**: Specify the path to the **ESP32 toolchain** (default is detected automatically).
-- **`--addr2line` or `-a`**: Specify the full path & name of your **addr2line utility** (used when the utility is not named 'xtensa-esp32-elf-addr2line')
+- **`--addr2line` or `-a`**: Specify the full path & name of your **addr2line utility** (used when the utility is not named 'xtensa-esp32-elf-addr2line.exe')
 - **`--com` or `-c`**: Specify the **COM port** for serial communication.
 - **`--speed` or `-s`**: Specify the **baud rate** for serial communication (default is `250000`).
 - **`--file` or `-f`**: Use a **file** as input for backtrace logs instead of serial.

--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,7 @@ This will build the project and prepare it for execution.
 
 After building the project, copy the generated **`ESP32_ExceptionDecoder`** binary to your PlatformIO project directory.
 
-For example, you can create a directory named **`eDecoder`** in your PlatformIO project folder and copy the binary there. You should copy the **DLL** and **EXE** (Windows) files from your build directory to **`eDecoder`**.
+For example, you can create a directory named **`eDecoder`** in your PlatformIO project folder and copy the binary there. For Windows, copy all files from your build directory to **`eDecoder`**.
 
 ### **Step 2: Execute the Tool**
 
@@ -79,6 +79,7 @@ You can also pass custom arguments to the tool if needed:
 - **`--build` or `-b`**: Specify the build directory or target build.
 - **`--elf` or `-e`**: Specify the **ELF file**.
 - **`--tools` or `-t`**: Specify the path to the **ESP32 toolchain** (default is detected automatically).
+- **`--addr2line` or `-a`**: Specify the full path & name of your addr2line utility** 
 - **`--com` or `-c`**: Specify the **COM port** for serial communication.
 - **`--speed` or `-s`**: Specify the **baud rate** for serial communication (default is `250000`).
 - **`--file` or `-f`**: Use a **file** as input for backtrace logs instead of serial.


### PR DESCRIPTION
Hi umartechboy,

Firstly, a big thank you for writing and publishing this most useful utility.

This is my first pull request on Github, I hope it is OK.

I am developing for a genuine Espressif ESP32-S3-DEVKITC-1U-N8R8 under the Arduino v3 framework,  using pioarduino (v1.0.8) and VSCode (v1.103.1) under Windows 11 (24H2, 64bit).  I already had dotNet SDK v 9.0.7, but installed the SDK v 8.0 for your package.  This board has 2 USB ports:-
•	Native “USB” that has 2 logical ports, used for JTAG debugging (when it works) and serial port, mapped to my PC’s COM6
•	“UART” port via an on-board FDDI converter, mapped to my PC’s COM5 

I have noticed the following issued, that I have addressed as detailed below:-
1.	In Step 1 of “Usage” on your github page, it states that the DLL and EXE files are to be copied to the eDecoder folder.  I found that all the files in the build’s bin folder needed to be copied.
2.	When attempting to run ESP32_ExceptionDecoder, I got the following exception
Unhandled exception. System.ComponentModel.Win32Exception (2): An error occurred trying to start process 'C:\Users\<user>\.platformio\packages\toolchain-xtensa-esp32s3\bin\xtensa-esp32-elf-addr2line' with working directory 'D:\Embedded\PIO\Traverser\Controller'. The system cannot find the file specified.
This was despite specifying my tools folder with
-t "C:\Users\<user>\.platformio\packages\toolchain-xtensa-esp32s3".  
This was resolved by copying xtensa-esp32s3-elf-addr2line.exe as xtensa-esp32-elf-addr2line.exe in the above folder.
3.	The command line options of --com "COM5" --speed 115200 as your tool reports “Opening COM5 @ 250000”.  As it happens, this usually works as both COM5 and COM6 are both connected to my ESP32-S3 board and are usable, but sometimes display gibberish.   Others may not be so fortunate. 
4.	My ESP32-S3 app includes a serial UI for debugging.  When your ESP32_ExceptionDecoder is connected to “UART” / COM5, I cannot send any ASCII commands.  
5.	Decoding a crash file was not working, because the file is only opened for an odd number of command line arguments, which should always be even number (the name of ESP32_ExceptionDecoder is not counted as an argument).

I don’t understand your test “if (bool.Parse(args[i + 1]))” in your line 134.  Why would anybody enter either “-c True” or “-c False” ?

I have changed your code by forking from your GitHub repo umartechboy/ESP32_ExceptionDecoder on 22 August 2025, 

These changes address the above numbered problems that I found:-

Issue #1
I have updated Readme.md

Issue #2
I have added another option of --a or --addr2line so that the full path and filename of the *addr2line utility may be specified (also updated Readme.md)

Issue #3
Because you had a ‘break’ statement after every matching argument, only the first command line argument was being used.  I have also simplified the for (int i … statement.  

Issue #4
I modified your code, for sending keyboard message to the ESP32.  This now sends character-by- character without awaiting a new line.

I have only tested under Windows 11.

Issue #4
I have changed:-
a)	Provided a separate string to hold the name of the trace file
b)	Changed type of ‘allTrace’ from var to string
c)	Changed the logic when usePort is false at the end of “Summarize on console what args are we going to use:”.
d)	Changed “foreach (var l in allTrace.Split('\r', 'n'))” to “foreach (var l in allTrace.Split('\r', '\n'))”, previously lines were being split on every ‘n’ character.
e)	Not calling newline() for empty lines (which is at least every other line since making above change (d)).

